### PR TITLE
Add WindowsDriveMapper to osfs package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,157 @@
+# osfs - OS Filesystem Implementation for absfs
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/absfs/osfs.svg)](https://pkg.go.dev/github.com/absfs/osfs)
+
+Package `osfs` provides an implementation of the `absfs.FileSystem` interface that wraps the standard Go `os` package, allowing direct interaction with the operating system's filesystem.
+
+## Installation
+
+```bash
+go get github.com/absfs/osfs
+```
+
+## Basic Usage
+
+```go
+import "github.com/absfs/osfs"
+
+// Create a new OS filesystem
+fs, err := osfs.NewFS()
+if err != nil {
+    log.Fatal(err)
+}
+
+// Use it like any absfs.FileSystem
+file, err := fs.Create("/path/to/file.txt")
+if err != nil {
+    log.Fatal(err)
+}
+defer file.Close()
+```
+
+## Features
+
+- **Full absfs.FileSystem implementation**: Implements all methods of the absfs interface
+- **Direct OS access**: All operations map directly to Go's `os` package
+- **Working directory management**: Maintains an internal working directory
+- **Cross-platform**: Works on Unix, Linux, macOS, and Windows
+- **Fast filesystem walking**: Includes optimized `FastWalk` implementation
+
+## Windows Drive Mapping
+
+On Windows, the `WindowsDriveMapper` wrapper provides intuitive path translation for cross-platform code:
+
+```go
+import "github.com/absfs/osfs"
+
+// Create a mapper that translates virtual-absolute paths
+fs, err := osfs.NewFS()
+if err != nil {
+    log.Fatal(err)
+}
+mapped := osfs.NewWindowsDriveMapper(fs, "C:")
+
+// Unix-style paths automatically map to Windows paths
+mapped.Create("/config/app.json")      // → C:\config\app.json
+mapped.MkdirAll("/var/log/app", 0755)  // → C:\var\log\app
+
+// OS-absolute paths pass through unchanged
+mapped.Open("C:\\Windows\\file.txt")   // → C:\Windows\file.txt
+mapped.Open("D:\\Data\\file.txt")      // → D:\Data\file.txt
+
+// UNC paths work correctly
+mapped.Open("\\\\server\\share\\file") // → \\server\share\file
+
+// On Unix/macOS, the mapper is a no-op
+mapped.Create("/config/app.json")      // → /config/app.json
+```
+
+### When to use WindowsDriveMapper
+
+**Use it when:**
+- Writing cross-platform CLI tools that work with OS filesystems
+- Porting Unix-based tools to Windows
+- You want `/path` semantics to map to `C:\path` on Windows
+
+**Don't use it when:**
+- Working with virtual/in-memory filesystems (use base absfs)
+- You need full control over Windows drive letters in your code
+- Testing with mock filesystems
+
+See [absfs PATH_HANDLING.md](https://github.com/absfs/absfs/blob/main/PATH_HANDLING.md) for more details on cross-platform path handling.
+
+### Custom Drive Letters
+
+You can specify a different drive letter:
+
+```go
+// Use D: drive instead of C:
+mapped := osfs.NewWindowsDriveMapper(fs, "D:")
+mapped.Create("/data/file.txt")  // → D:\data\file.txt
+```
+
+If you don't specify a drive, it defaults to `C:`.
+
+## API Overview
+
+The `FileSystem` type implements the following methods:
+
+### File Operations
+- `Open(name string) (absfs.File, error)`
+- `Create(name string) (absfs.File, error)`
+- `OpenFile(name string, flag int, perm os.FileMode) (absfs.File, error)`
+- `Truncate(name string, size int64) error`
+
+### Directory Operations
+- `Mkdir(name string, perm os.FileMode) error`
+- `MkdirAll(path string, perm os.FileMode) error`
+- `Remove(name string) error`
+- `RemoveAll(path string) error`
+- `Chdir(dir string) error`
+- `Getwd() (dir string, err error)`
+
+### File Information
+- `Stat(name string) (os.FileInfo, error)`
+- `Lstat(name string) (os.FileInfo, error)`
+
+### File Attributes
+- `Chmod(name string, mode os.FileMode) error`
+- `Chtimes(name string, atime time.Time, mtime time.Time) error`
+- `Chown(name string, uid, gid int) error`
+- `Lchown(name string, uid, gid int) error`
+
+### Path Operations
+- `Rename(oldpath, newpath string) error`
+- `Symlink(oldname, newname string) error`
+- `Readlink(name string) (string, error)`
+
+### Filesystem Walking
+- `Walk(path string, fn func(string, os.FileInfo, error) error) error`
+- `FastWalk(path string, fn func(string, os.FileMode) error) error`
+
+### System Information
+- `Separator() uint8` - Returns the OS-specific path separator
+- `ListSeparator() uint8` - Returns the OS-specific list separator
+- `TempDir() string` - Returns the temporary directory path
+
+## FastWalk
+
+The `FastWalk` method provides optimized filesystem traversal:
+
+```go
+fs, _ := osfs.NewFS()
+err := fs.FastWalk("/path/to/dir", func(path string, mode os.FileMode) error {
+    fmt.Println(path, mode)
+    return nil
+})
+```
+
+FastWalk is significantly faster than `Walk` for large directory trees because it avoids unnecessary stat calls.
+
+## License
+
+See the main [absfs repository](https://github.com/absfs/absfs) for license information.
+
+## Contributing
+
+Contributions are welcome! Please see the main [absfs repository](https://github.com/absfs/absfs) for contribution guidelines.

--- a/drivemapper_test.go
+++ b/drivemapper_test.go
@@ -1,0 +1,223 @@
+// +build windows
+
+package osfs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWindowsDriveMapperTranslatePath(t *testing.T) {
+	base, err := NewFS()
+	if err != nil {
+		t.Fatalf("NewFS failed: %v", err)
+	}
+	mapper := NewWindowsDriveMapper(base, "C:").(*WindowsDriveMapper)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Virtual-absolute with forward slash",
+			input:    "/config/app.json",
+			expected: "C:\\config\\app.json",
+		},
+		{
+			name:     "Virtual-absolute with backslash",
+			input:    "\\var\\log\\app.log",
+			expected: "C:\\var\\log\\app.log",
+		},
+		{
+			name:     "OS-absolute with drive letter",
+			input:    "C:\\Windows\\System32\\file.txt",
+			expected: "C:\\Windows\\System32\\file.txt",
+		},
+		{
+			name:     "OS-absolute with different drive",
+			input:    "D:\\Data\\file.txt",
+			expected: "D:\\Data\\file.txt",
+		},
+		{
+			name:     "UNC path",
+			input:    "\\\\server\\share\\file.txt",
+			expected: "\\\\server\\share\\file.txt",
+		},
+		{
+			name:     "Relative path",
+			input:    "relative\\path\\file.txt",
+			expected: "relative\\path\\file.txt",
+		},
+		{
+			name:     "Root path",
+			input:    "/",
+			expected: "C:\\",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapper.translatePath(tt.input)
+			expected := filepath.Clean(tt.expected)
+			result = filepath.Clean(result)
+
+			if result != expected {
+				t.Errorf("translatePath(%q) = %q, want %q", tt.input, result, expected)
+			}
+		})
+	}
+}
+
+func TestWindowsDriveMapperDefaultDrive(t *testing.T) {
+	base, err := NewFS()
+	if err != nil {
+		t.Fatalf("NewFS failed: %v", err)
+	}
+	mapper := NewWindowsDriveMapper(base, "").(*WindowsDriveMapper)
+
+	if mapper.drive != "C:" {
+		t.Errorf("Expected default drive C:, got %s", mapper.drive)
+	}
+}
+
+func TestWindowsDriveMapperCustomDrive(t *testing.T) {
+	base, err := NewFS()
+	if err != nil {
+		t.Fatalf("NewFS failed: %v", err)
+	}
+	mapper := NewWindowsDriveMapper(base, "D:").(*WindowsDriveMapper)
+
+	if mapper.drive != "D:" {
+		t.Errorf("Expected drive D:, got %s", mapper.drive)
+	}
+
+	result := mapper.translatePath("/data/file.txt")
+	expected := filepath.Clean("D:\\data\\file.txt")
+	result = filepath.Clean(result)
+
+	if result != expected {
+		t.Errorf("translatePath with D: drive = %q, want %q", result, expected)
+	}
+}
+
+func TestWindowsDriveMapperIntegration(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	base, err := NewFS()
+	if err != nil {
+		t.Fatalf("NewFS failed: %v", err)
+	}
+	mapper := NewWindowsDriveMapper(base, "C:")
+
+	// Test that OS-absolute paths work unchanged
+	testFile := filepath.Join(tempDir, "test.txt")
+	f, err := mapper.Create(testFile)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	f.Close()
+
+	// Verify file was created
+	_, err = mapper.Stat(testFile)
+	if err != nil {
+		t.Errorf("Stat failed: %v", err)
+	}
+
+	// Clean up
+	err = mapper.Remove(testFile)
+	if err != nil {
+		t.Errorf("Remove failed: %v", err)
+	}
+}
+
+func TestWindowsDriveMapperPassThroughMethods(t *testing.T) {
+	base, err := NewFS()
+	if err != nil {
+		t.Fatalf("NewFS failed: %v", err)
+	}
+	mapper := NewWindowsDriveMapper(base, "C:")
+
+	// Test methods that should pass through unchanged
+	if sep := mapper.Separator(); sep != base.Separator() {
+		t.Errorf("Separator() = %c, want %c", sep, base.Separator())
+	}
+
+	if listSep := mapper.ListSeparator(); listSep != base.ListSeparator() {
+		t.Errorf("ListSeparator() = %c, want %c", listSep, base.ListSeparator())
+	}
+
+	if tempDir := mapper.TempDir(); tempDir != base.TempDir() {
+		t.Errorf("TempDir() = %s, want %s", tempDir, base.TempDir())
+	}
+}
+
+func TestWindowsDriveMapperAllMethods(t *testing.T) {
+	tempDir := t.TempDir()
+	base, err := NewFS()
+	if err != nil {
+		t.Fatalf("NewFS failed: %v", err)
+	}
+	mapper := NewWindowsDriveMapper(base, "C:")
+
+	// Test various FileSystem methods with OS-absolute paths
+	testPath := filepath.Join(tempDir, "test")
+
+	// Mkdir
+	err = mapper.Mkdir(testPath, 0755)
+	if err != nil {
+		t.Errorf("Mkdir failed: %v", err)
+	}
+
+	// Stat
+	info, err := mapper.Stat(testPath)
+	if err != nil {
+		t.Errorf("Stat failed: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("Expected directory")
+	}
+
+	// Create file
+	filePath := filepath.Join(testPath, "file.txt")
+	f, err := mapper.Create(filePath)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	f.Close()
+
+	// Chmod
+	err = mapper.Chmod(filePath, 0644)
+	if err != nil {
+		t.Errorf("Chmod failed: %v", err)
+	}
+
+	// Chtimes
+	now := time.Now()
+	err = mapper.Chtimes(filePath, now, now)
+	if err != nil {
+		t.Errorf("Chtimes failed: %v", err)
+	}
+
+	// Rename
+	newPath := filepath.Join(testPath, "renamed.txt")
+	err = mapper.Rename(filePath, newPath)
+	if err != nil {
+		t.Errorf("Rename failed: %v", err)
+	}
+
+	// Truncate
+	err = mapper.Truncate(newPath, 100)
+	if err != nil {
+		t.Errorf("Truncate failed: %v", err)
+	}
+
+	// RemoveAll
+	err = mapper.RemoveAll(testPath)
+	if err != nil {
+		t.Errorf("RemoveAll failed: %v", err)
+	}
+}

--- a/drivemapper_unix.go
+++ b/drivemapper_unix.go
@@ -1,0 +1,22 @@
+// +build !windows
+
+package osfs
+
+import "github.com/absfs/absfs"
+
+// NewWindowsDriveMapper on non-Windows platforms simply returns the base FileSystem
+// unchanged, since virtual-absolute paths already work correctly on Unix-like systems.
+//
+// This no-op implementation ensures code using NewWindowsDriveMapper compiles and
+// runs correctly on all platforms without conditional compilation in user code.
+//
+// Example:
+//   // This code works on all platforms:
+//   fs, _ := osfs.NewFS()
+//   mapped := osfs.NewWindowsDriveMapper(fs, "C:")
+//   mapped.Create("/config/app.json")
+//   // On Unix/macOS: creates /config/app.json
+//   // On Windows: creates C:\config\app.json
+func NewWindowsDriveMapper(base absfs.FileSystem, drive string) absfs.FileSystem {
+	return base
+}

--- a/drivemapper_windows.go
+++ b/drivemapper_windows.go
@@ -1,0 +1,143 @@
+// +build windows
+
+package osfs
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/absfs/absfs"
+)
+
+// WindowsDriveMapper wraps an absfs.FileSystem and translates virtual-absolute
+// paths to OS-absolute paths on Windows by prepending a drive letter.
+//
+// This is useful when you want Unix-style absolute paths like "/config/app.json"
+// to map to Windows paths like "C:\config\app.json" for OS filesystem operations.
+//
+// Path translation rules:
+//   - Virtual-absolute (starts with / or \) → Prepend drive letter
+//   - OS-absolute (has drive letter or UNC) → Pass through unchanged
+//   - Relative paths → Pass through unchanged
+//
+// Example:
+//   fs, _ := osfs.NewFS()
+//   mapped := osfs.NewWindowsDriveMapper(fs, "C:")
+//
+//   mapped.Create("/config/app.json")      // → C:\config\app.json
+//   mapped.Open("C:\\Windows\\file.txt")   // → C:\Windows\file.txt (unchanged)
+//   mapped.MkdirAll("/var/log", 0755)      // → C:\var\log
+type WindowsDriveMapper struct {
+	base  absfs.FileSystem
+	drive string
+}
+
+// NewWindowsDriveMapper creates a new WindowsDriveMapper that wraps the given
+// FileSystem and translates virtual-absolute paths to use the specified drive.
+//
+// If drive is empty, defaults to "C:". Drive should be in the format "C:" or "D:".
+func NewWindowsDriveMapper(base absfs.FileSystem, drive string) absfs.FileSystem {
+	if drive == "" {
+		drive = "C:"
+	}
+	return &WindowsDriveMapper{
+		base:  base,
+		drive: drive,
+	}
+}
+
+// translatePath converts virtual-absolute paths to OS-absolute paths.
+// OS-absolute and relative paths pass through unchanged.
+func (w *WindowsDriveMapper) translatePath(path string) string {
+	// Already OS-absolute (has drive letter or UNC) - no translation needed
+	if filepath.IsAbs(path) {
+		return path
+	}
+
+	// Virtual-absolute (starts with / or \) - add drive letter
+	if len(path) > 0 && (path[0] == '/' || path[0] == '\\') {
+		return filepath.Join(w.drive+"\\", path)
+	}
+
+	// Relative path - no translation
+	return path
+}
+
+// Implement all absfs.FileSystem interface methods with path translation
+
+func (w *WindowsDriveMapper) OpenFile(name string, flag int, perm os.FileMode) (absfs.File, error) {
+	return w.base.OpenFile(w.translatePath(name), flag, perm)
+}
+
+func (w *WindowsDriveMapper) Mkdir(name string, perm os.FileMode) error {
+	return w.base.Mkdir(w.translatePath(name), perm)
+}
+
+func (w *WindowsDriveMapper) Remove(name string) error {
+	return w.base.Remove(w.translatePath(name))
+}
+
+func (w *WindowsDriveMapper) Rename(oldpath, newpath string) error {
+	return w.base.Rename(w.translatePath(oldpath), w.translatePath(newpath))
+}
+
+func (w *WindowsDriveMapper) Stat(name string) (os.FileInfo, error) {
+	return w.base.Stat(w.translatePath(name))
+}
+
+func (w *WindowsDriveMapper) Chmod(name string, mode os.FileMode) error {
+	return w.base.Chmod(w.translatePath(name), mode)
+}
+
+func (w *WindowsDriveMapper) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return w.base.Chtimes(w.translatePath(name), atime, mtime)
+}
+
+func (w *WindowsDriveMapper) Chown(name string, uid, gid int) error {
+	return w.base.Chown(w.translatePath(name), uid, gid)
+}
+
+// Extended FileSystem methods
+
+func (w *WindowsDriveMapper) Open(name string) (absfs.File, error) {
+	return w.base.Open(w.translatePath(name))
+}
+
+func (w *WindowsDriveMapper) Create(name string) (absfs.File, error) {
+	return w.base.Create(w.translatePath(name))
+}
+
+func (w *WindowsDriveMapper) MkdirAll(path string, perm os.FileMode) error {
+	return w.base.MkdirAll(w.translatePath(path), perm)
+}
+
+func (w *WindowsDriveMapper) RemoveAll(path string) error {
+	return w.base.RemoveAll(w.translatePath(path))
+}
+
+func (w *WindowsDriveMapper) Truncate(name string, size int64) error {
+	return w.base.Truncate(w.translatePath(name), size)
+}
+
+func (w *WindowsDriveMapper) Chdir(dir string) error {
+	return w.base.Chdir(w.translatePath(dir))
+}
+
+// Pass-through methods (no path translation needed)
+
+func (w *WindowsDriveMapper) Separator() uint8 {
+	return w.base.Separator()
+}
+
+func (w *WindowsDriveMapper) ListSeparator() uint8 {
+	return w.base.ListSeparator()
+}
+
+func (w *WindowsDriveMapper) Getwd() (dir string, err error) {
+	return w.base.Getwd()
+}
+
+func (w *WindowsDriveMapper) TempDir() string {
+	return w.base.TempDir()
+}

--- a/example_drivemapper_test.go
+++ b/example_drivemapper_test.go
@@ -1,0 +1,53 @@
+// +build windows
+
+package osfs_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/absfs/osfs"
+)
+
+func ExampleNewWindowsDriveMapper() {
+	// Create an OS filesystem with drive mapping
+	fs, err := osfs.NewFS()
+	if err != nil {
+		log.Fatal(err)
+	}
+	mapped := osfs.NewWindowsDriveMapper(fs, "C:")
+
+	// Unix-style paths work intuitively on Windows
+	f, err := mapped.Create("/tmp/config.json")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	// This created C:\tmp\config.json on Windows
+	// and /tmp/config.json on Unix/macOS
+
+	fmt.Println("Config file created")
+	// Output: Config file created
+}
+
+func ExampleNewWindowsDriveMapper_customDrive() {
+	// Use a different drive letter
+	fs, err := osfs.NewFS()
+	if err != nil {
+		log.Fatal(err)
+	}
+	mapped := osfs.NewWindowsDriveMapper(fs, "D:")
+
+	// Paths map to D: drive instead
+	err = mapped.MkdirAll("/data/logs", 0755)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// This created D:\data\logs on Windows
+	// and /data/logs on Unix/macOS
+
+	fmt.Println("Directory created")
+	// Output: Directory created
+}


### PR DESCRIPTION
Adds WindowsDriveMapper wrapper that translates virtual-absolute paths (like /config/app.json) to OS-absolute paths on Windows (like C:\config\app.json). This enables cross-platform code to work intuitively with the OS filesystem on Windows while maintaining Unix-style path semantics.

Features:
- Windows-specific implementation with drive letter mapping
- Unix no-op stub for seamless cross-platform usage
- Comprehensive tests and examples
- Full README documentation

Path translation rules:
- Virtual-absolute (starts with / or \) → Prepend drive letter
- OS-absolute (has drive letter or UNC) → Pass through unchanged
- Relative paths → Pass through unchanged